### PR TITLE
prevent duplicate wrappers being added to an input element when ezMark i...

### DIFF
--- a/js/jquery.ezmark.js
+++ b/js/jquery.ezmark.js
@@ -41,6 +41,10 @@
 	};
     return this.each(function() {
     	var $this = $(this);
+    	
+    	// back out if the object in question has already been wrapped in an ezMark wrappers
+        if($this.parent().hasClass(defaultOpt.checkboxCls) || $this.parent().hasClass(defaultOpt.radioCls)) return;
+    	
     	var wrapTag = $this.attr('type') == 'checkbox' ? '<div class="'+defaultOpt.checkboxCls+'">' : '<div class="'+defaultOpt.radioCls+'">';
     	// for checkbox
     	if( $this.attr('type') == 'checkbox') {


### PR DESCRIPTION
...s called multiple times on a selector.  I've found that I needed to add ezMark calls on ajaxComplete events so that dynamically loaded content can also have fancy checkboxes with as little code/coupling as possible.
